### PR TITLE
Implement table sorting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "explorer.autoReveal": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "typescript.preferences.importModuleSpecifier": "non-relative",
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  },
-  "explorer.autoReveal": true
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     volumes:
       - psql:/var/lib/postgresql/data
     ports:
-      - 5433:5432
+      - 5432:5432
 volumes:
   psql:

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,14 +1,49 @@
 import { NextRequest, NextResponse } from "next/server";
 import { advocates } from "@/db/schema";
-import { count, or, ilike, sql } from "drizzle-orm";
+import { count, or, ilike, sql, asc, desc } from "drizzle-orm";
 import db from "@/db";
+
+enum SortOrder {
+  ASC = "asc",
+  DESC = "desc",
+}
 
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
   const page = parseInt(searchParams.get("page") || "1", 10);
   const limit = parseInt(searchParams.get("limit") || "10", 10);
   const search = searchParams.get("search");
+  const sortBy = searchParams.get("sortBy");
+  const sortOrder = searchParams.get("sortOrder") || SortOrder.ASC;
   const offset = (page - 1) * limit;
+
+  // Build sort condition
+  let orderByClause;
+  if (sortBy) {
+    const sortDirection = sortOrder === SortOrder.DESC ? desc : asc;
+
+    switch (sortBy) {
+      case "firstName":
+        orderByClause = sortDirection(advocates.firstName);
+        break;
+      case "lastName":
+        orderByClause = sortDirection(advocates.lastName);
+        break;
+      case "city":
+        orderByClause = sortDirection(advocates.city);
+        break;
+      case "degree":
+        orderByClause = sortDirection(advocates.degree);
+        break;
+      case "yearsOfExperience":
+        orderByClause = sortDirection(advocates.yearsOfExperience);
+        break;
+      default:
+        orderByClause = asc(advocates.id); // Default sort
+    }
+  } else {
+    orderByClause = asc(advocates.id); // Default sort by id
+  }
 
   // Build search conditions if search term is provided
   let data, totalRecords;
@@ -21,15 +56,18 @@ export async function GET(req: NextRequest) {
       ilike(advocates.lastName, searchTerm),
       ilike(advocates.city, searchTerm),
       ilike(advocates.degree, searchTerm),
+      // Search in specialties array (JSONB field)
       sql`${advocates.specialties}::text ILIKE ${searchTerm}`,
+      // Search in years of experience (convert to text)
       sql`${advocates.yearsOfExperience}::text ILIKE ${searchTerm}`
     );
 
-    // Execute queries with search conditions
+    // Execute queries with search conditions and sorting
     data = await db
       .select()
       .from(advocates)
       .where(searchConditions)
+      .orderBy(orderByClause)
       .limit(limit)
       .offset(offset);
 
@@ -38,8 +76,13 @@ export async function GET(req: NextRequest) {
       .from(advocates)
       .where(searchConditions);
   } else {
-    // Execute queries without search conditions
-    data = await db.select().from(advocates).limit(limit).offset(offset);
+    // Execute queries without search conditions but with sorting
+    data = await db
+      .select()
+      .from(advocates)
+      .orderBy(orderByClause)
+      .limit(limit)
+      .offset(offset);
 
     totalRecords = await db.select({ value: count() }).from(advocates);
   }
@@ -51,6 +94,8 @@ export async function GET(req: NextRequest) {
       page,
       limit,
       search: search || null,
+      sortBy: sortBy || null,
+      sortOrder: sortOrder || SortOrder.ASC,
     },
   });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,10 +93,9 @@ export default function Home() {
   }
 
   return (
-    <main className="m-6">
-      <h1 className="m-6">Solace Advocates</h1>
-
-      <div className="m-6">
+    <main className="flex flex-col gap-6 p-6">
+      <h1>Solace Advocates</h1>
+      <div>
         {searchText && (
           <p className="mb-4 text-gray-600">
             Searching for: <strong>{searchText}</strong>
@@ -106,7 +105,7 @@ export default function Home() {
         <Search
           placeholder="Search by name, city, degree, specialties, or experience..."
           allowClear
-          style={{ width: 400 }}
+          className="w-96"
           onChange={(e) => debouncedSearch(e.target.value)}
           onSearch={debouncedSearch}
         />
@@ -120,11 +119,7 @@ export default function Home() {
         onChange={(_pagination, _filters, sorter, extra) =>
           extra.action === "sort" ? tableSorterToOrderParameters(sorter) : null
         }
-        style={{
-          border: "1px solid #f0f0f0",
-          borderRadius: "8px",
-          backgroundColor: "white",
-        }}
+        className="border border-gray-200 rounded-lg bg-white"
       >
         <Column
           title="First Name"
@@ -196,8 +191,6 @@ export default function Home() {
           current={currentPage}
           pageSize={pageSize}
           total={meta.total}
-          showSizeChanger={true}
-          showQuickJumper={true}
           showTotal={(total, range) =>
             `${range[0]}-${range[1]} of ${total} advocates`
           }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,10 @@
 import { useState, useMemo, useCallback } from "react";
 import { Table, Pagination, Tag } from "antd";
 import Search from "antd/lib/input/Search";
+import { SorterResult } from "antd/lib/table/interface";
 import { useGetAdvocates } from "@/hooks/useGetAdvocates";
 import { AdvocatesInterface } from "@/db/schema";
+import { Order, sortState } from "@/util/tableUtil";
 
 const { Column } = Table;
 
@@ -13,12 +15,18 @@ export default function Home() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
-  const { advocates, meta, loading, error } = useGetAdvocates({
+  // Default order is by firstName in ascending order
+  const [orderInfo, setOrderInfo] = useState<Order>();
+
+  const [paginationParameters, setPaginationParameters] = useState({
+    page: currentPage,
+    pageSize: pageSize,
+  });
+
+  const { advocates, meta, isLoading, error } = useGetAdvocates({
     search: searchText,
-    paginationParameters: {
-      page: currentPage,
-      pageSize: pageSize,
-    },
+    paginationParameters,
+    orderInfo,
   });
 
   const handleSearch = useCallback((searchTerm: string) => {
@@ -40,6 +48,20 @@ export default function Home() {
   const handlePagination = (page: number, size: number) => {
     setCurrentPage(page);
     setPageSize(size);
+    setPaginationParameters({ page, pageSize: size });
+  };
+
+  // Transform Ant Design sorter to Order parameters
+  const tableSorterToOrderParameters = (
+    sorterOrList: SorterResult<any> | SorterResult<any>[]
+  ) => {
+    const sorter = Array.isArray(sorterOrList) ? sorterOrList[0] : sorterOrList;
+    // If order is undefined, no order is set -> remove order parameters
+    if (sorter.column === undefined) {
+      setOrderInfo({ columnKey: undefined, order: undefined });
+    } else {
+      setOrderInfo({ columnKey: sorter.columnKey, order: sorter.order });
+    }
   };
 
   // Add unique keys to data source to prevent the unique key warning
@@ -50,7 +72,7 @@ export default function Home() {
 
   if (error) {
     return (
-      <main style={{ margin: "24px" }}>
+      <main className="m-6">
         <h1>Error loading advocates</h1>
         <p>Please try again later.</p>
       </main>
@@ -73,9 +95,9 @@ export default function Home() {
 
   return (
     <main className="m-6">
-      <h1 className="mb-6">Solace Advocates</h1>
+      <h1 className="m-6">Solace Advocates</h1>
 
-      <div className="mb-6">
+      <div className="m-6">
         {searchText && (
           <p className="mb-4 text-gray-600">
             Searching for: <strong>{searchText}</strong>
@@ -93,9 +115,12 @@ export default function Home() {
 
       <Table
         dataSource={dataSource}
-        loading={loading}
+        loading={isLoading}
         pagination={false}
         scroll={{ x: 800 }}
+        onChange={(_pagination, _filters, sorter, extra) =>
+          extra.action === "sort" ? tableSorterToOrderParameters(sorter) : null
+        }
         style={{
           border: "1px solid #f0f0f0",
           borderRadius: "8px",
@@ -106,28 +131,32 @@ export default function Home() {
           title="First Name"
           dataIndex="firstName"
           key="firstName"
-          sorter={(a, b) => a.firstName.localeCompare(b.firstName)}
+          sorter
+          defaultSortOrder={sortState(orderInfo, "firstName")}
         />
 
         <Column
           title="Last Name"
           dataIndex="lastName"
           key="lastName"
-          sorter={(a, b) => a.lastName.localeCompare(b.lastName)}
+          sorter
+          defaultSortOrder={sortState(orderInfo, "lastName")}
         />
 
         <Column
           title="City"
           dataIndex="city"
           key="city"
-          sorter={(a, b) => a.city.localeCompare(b.city)}
+          sorter
+          defaultSortOrder={sortState(orderInfo, "city")}
         />
 
         <Column
           title="Degree"
           dataIndex="degree"
           key="degree"
-          sorter={(a, b) => a.degree.localeCompare(b.degree)}
+          sorter
+          defaultSortOrder={sortState(orderInfo, "degree")}
         />
 
         <Column
@@ -149,7 +178,8 @@ export default function Home() {
           title="Years of Experience"
           dataIndex="yearsOfExperience"
           key="yearsOfExperience"
-          sorter={(a, b) => a.yearsOfExperience - b.yearsOfExperience}
+          sorter
+          defaultSortOrder={sortState(orderInfo, "yearsOfExperience")}
           align="center"
         />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,6 @@ export default function Home() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
 
-  // Default order is by firstName in ascending order
   const [orderInfo, setOrderInfo] = useState<Order>();
 
   const [paginationParameters, setPaginationParameters] = useState({

--- a/src/hooks/useGetAdvocates.ts
+++ b/src/hooks/useGetAdvocates.ts
@@ -1,12 +1,14 @@
 import useSWR from "swr";
-import { AdvocatesInterface } from "../db/schema";
+import { AdvocatesInterface } from "@/db/schema";
+import { buildOrderParams, Order, toQueryString } from "@/util/tableUtil";
 
 type Props = {
-  search?: string;
-  paginationParameters: {
+  paginationParameters?: {
     page: number;
     pageSize: number;
   };
+  search?: string;
+  orderInfo?: Order;
 };
 
 interface AdvocatesResponse {
@@ -15,30 +17,44 @@ interface AdvocatesResponse {
     total: number;
     page: number;
     limit: number;
+    search?: string | null;
+    sortBy?: string | null;
+    sortOrder?: string;
   };
 }
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-// Fetches advocates with pagination and search support
-export const useGetAdvocates = ({ search, paginationParameters }: Props) => {
+export const useGetAdvocates = ({
+  paginationParameters,
+  search,
+  orderInfo,
+}: Props) => {
   const parameters: Record<string, string> = {};
 
-  if (paginationParameters.page) {
+  if (paginationParameters?.page) {
     parameters["page"] = paginationParameters.page.toString();
     parameters["limit"] = paginationParameters.pageSize.toString();
+  }
+
+  // handle order parameters
+  const orderParams = buildOrderParams(orderInfo);
+  if (orderParams) {
+    parameters["sortBy"] = orderParams.order;
+    parameters["sortOrder"] = orderParams.sort;
   }
 
   if (search) {
     parameters["search"] = search;
   }
 
-  const queryString = new URLSearchParams(parameters).toString();
-  const url = `/api/advocates${queryString ? `?${queryString}` : ""}`;
+  // attach search parameters to URL
+  const queryString = toQueryString(parameters);
+  const url = `/api/advocates?${queryString}`;
 
   const {
     data,
-    isLoading: loading,
+    isLoading,
     error,
     isValidating,
     mutate: refetchAdvocates,
@@ -47,9 +63,9 @@ export const useGetAdvocates = ({ search, paginationParameters }: Props) => {
   return {
     advocates: data?.data ?? [],
     meta: data?.meta ?? { total: 0, page: 1, limit: 10 },
-    loading,
-    isValidating,
+    isLoading,
     error,
+    isValidating,
     refetchAdvocates,
   };
 };

--- a/src/util/tableUtil.ts
+++ b/src/util/tableUtil.ts
@@ -1,0 +1,46 @@
+import { Key, SortOrder } from "antd/lib/table/interface";
+
+export type Order = {
+  order: undefined | SortOrder;
+  columnKey: undefined | Key;
+};
+
+/**
+ * Transform ant.design table sorting parameters into request query parameters.
+ * @param order Order object to use to build parameters
+ * @returns Order query parameters in an object
+ */
+export const buildOrderParams = (order?: Order) => {
+  if (!order) return null;
+  if (order?.columnKey) {
+    const label = order.columnKey.toString();
+    const direction = order.order === "ascend" ? "asc" : "desc";
+    return { order: label, sort: direction };
+  }
+};
+
+/**
+ * Provide the SortOrder value for populating defaultSortOrder.
+ * @param columnKeyName string value that matches the column's columnKey value
+ * @returns SortOrder or undefined depending on whether the specified column is
+ *  actively being sorted.
+ */
+export const sortState = (
+  orderInfo: Order | undefined,
+  columnKeyName: string
+) => {
+  return orderInfo?.columnKey?.toString() === columnKeyName
+    ? orderInfo.order
+    : undefined;
+};
+
+/**
+ * Build a string containing the given query parameters.
+ * @param parameters Record containing the query parameter keys and values.
+ * @returns string with the query parameters from the Record.
+ */
+export function toQueryString(parameters: Record<string, string>): string {
+  return Object.entries(parameters)
+    .map((kv) => kv.map(encodeURIComponent).join("="))
+    .join("&");
+}


### PR DESCRIPTION
 - Implements the ability to sort the `advocates` table by different columns.
   - Excluding the `Specialties` column.
 - Polishes styles and replaces `style` props with tailwindcss classes.
 - Reverts DB port to 5432 from 5433 in docker-compose.yml. 